### PR TITLE
Add .claude/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ Thumbs.db
 # IDE/Editor files
 .vscode/
 .idea/
+.claude/
 *.swp
 *.swo
 *~


### PR DESCRIPTION
## Summary
- Add `.claude/` directory to `.gitignore` to exclude Claude Code configuration files from version control

## Changes
- Added `.claude/` entry to the IDE/Editor files section in `.gitignore`

## Rationale
The `.claude/` directory contains Claude Code-specific configuration and settings that are typically user-specific and should not be committed to the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)